### PR TITLE
add additional parameters

### DIFF
--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -1,4 +1,8 @@
 { "commands": [
+{ "hdr": "720", "dbg": true, "cmd": {"22": "61B1"}, "freq": 1,
+  "signals": [
+    {"id": "CX_90_FUEL_LEVEL", "path": "Fuel", "fmt": { "len": 8, "max": 55, "unit": "liters" }, "name": "Fuel level"}
+  ]},
 { "hdr": "726", "dbg": true, "cmd": {"22": "D922"}, "freq": 1,
   "signals": [
     {"id": "CX90_TP_FL", "path": "Tires", "fmt": { "len": 8, "max": 51, "div": 5, "unit": "psi" }, "name": "Front left pressure", "suggestedMetric": "frontLeftTirePressure"}
@@ -30,6 +34,22 @@
 { "hdr": "726", "dbg": true, "cmd": {"22": "D929"}, "freq": 1,
   "signals": [
     {"id": "CX90_TT_RR", "path": "Tires", "fmt": { "len": 8, "max": 205, "min": -50, "add": -50, "unit": "celsius" }, "name": "Rear right temperature"}
+  ]},
+{ "hdr": "7E0", "dbg": true, "cmd": {"22": "0301"}, "freq": 0.25,
+  "signals": [
+    {"id": "CX_90_MAP", "path": "Engine", "fmt": { "len": 16, "max": 4, "div": 1000, "unit": "volts" }, "name": "MAP voltage", "description": "A properly functioning sensor should read around 1 to 1.5 volts at idle."}
+  ]},
+{ "hdr": "7E0", "dbg": true, "cmd": {"22": "0307"}, "freq": 0.25,
+  "signals": [
+    {"id": "CX_90_FP_LD", "path": "Fuel", "fmt": { "len": 16, "max": 100, "mul": 100, "div": 65535, "unit": "percent" }, "name": "Fuel pump load"}
+  ]},
+{ "hdr": "7E0", "dbg": true, "cmd": {"22": "0415"}, "freq": 1,
+  "signals": [
+    {"id": "CX_90_EOP", "path": "Engine", "fmt": { "len": 16, "max": 32767, "min": -32768, "sign": true, "unit": "kilopascal" }, "name": "Engine oil pressure"}
+  ]},
+{ "hdr": "7E0", "dbg": true, "cmd": {"22": "1310"}, "freq": 1,
+  "signals": [
+    {"id": "CX_90_EOT", "path": "Engine", "fmt": { "len": 16, "max": 615.35, "min": -40, "div": 100, "add": -40, "unit": "celsius" }, "name": "Engine oil temperature"}
   ]}
 ]
 }


### PR DESCRIPTION
This pull request adds new signal definitions to the `signalsets/v3/default.json` file, expanding the dataset with additional telemetry signals for vehicle diagnostics. The changes include new signals related to fuel, engine, and tire data.

### Additions to signal definitions:

* **Fuel-related signals:**
  - Added `CX_90_FUEL_LEVEL` signal under the "Fuel" path to monitor fuel levels in liters.
  - Added `CX_90_FP_LD` signal under the "Fuel" path to track fuel pump load as a percentage.

* **Engine-related signals:**
  - Added `CX_90_MAP` signal under the "Engine" path to measure MAP (Manifold Absolute Pressure) voltage in volts, with a description for expected idle values.
  - Added `CX_90_EOP` signal under the "Engine" path to monitor engine oil pressure in kilopascals.
  - Added `CX_90_EOT` signal under the "Engine" path to track engine oil temperature in Celsius.

These additions enhance the diagnostic capabilities by providing more granular and diverse vehicle telemetry data.